### PR TITLE
Change how module configuration gear ratios are specified

### DIFF
--- a/src/main/java/com/swervedrivespecialties/swervelib/ModuleConfiguration.java
+++ b/src/main/java/com/swervedrivespecialties/swervelib/ModuleConfiguration.java
@@ -1,21 +1,26 @@
 package com.swervedrivespecialties.swervelib;
 
-import java.util.Arrays;
 import java.util.Objects;
 
 public class ModuleConfiguration {
     private final String modelIdentifier;
 
     private final double wheelDiameter;
-    private final double[] driveReductions;
+    private final double driveReduction;
+    private final boolean driveInverted;
 
-    private final double[] steerReductions;
+    private final double steerReduction;
+    private final boolean steerInverted;
 
-    public ModuleConfiguration(String modelIdentifier, double wheelDiameter, double[] driveReductions, double[] steerReductions) {
-        this.modelIdentifier = modelIdentifier;
+    public ModuleConfiguration(String modelIdentifier,
+                               double wheelDiameter, double driveReduction, boolean driveInverted,
+                               double steerReduction, boolean steerInverted) {
+        this.modelIdentifier = Objects.requireNonNull(modelIdentifier);
         this.wheelDiameter = wheelDiameter;
-        this.driveReductions = driveReductions;
-        this.steerReductions = steerReductions;
+        this.driveReduction = driveReduction;
+        this.driveInverted = driveInverted;
+        this.steerReduction = steerReduction;
+        this.steerInverted = steerInverted;
     }
 
     public String getModelIdentifier() {
@@ -26,20 +31,20 @@ public class ModuleConfiguration {
         return wheelDiameter;
     }
 
-    public double[] getDriveReductions() {
-        return driveReductions;
+    public double getDriveReduction() {
+        return driveReduction;
     }
 
-    public double getOverallDriveReduction() {
-        return Arrays.stream(getDriveReductions()).reduce(1.0, (a, b) -> a * b);
+    public boolean isDriveInverted() {
+        return driveInverted;
     }
 
-    public double[] getSteerReductions() {
-        return steerReductions;
+    public double getSteerReduction() {
+        return steerReduction;
     }
 
-    public double getOverallSteerReduction() {
-        return Arrays.stream(getSteerReductions()).reduce(1.0, (a, b) -> a * b);
+    public boolean isSteerInverted() {
+        return steerInverted;
     }
 
     @Override
@@ -47,15 +52,25 @@ public class ModuleConfiguration {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ModuleConfiguration that = (ModuleConfiguration) o;
-        return Double.compare(that.wheelDiameter, wheelDiameter) == 0 && modelIdentifier.equals(that.modelIdentifier) && Arrays.equals(driveReductions, that.driveReductions) && Arrays.equals(steerReductions, that.steerReductions);
+        return Double.compare(
+                that.getWheelDiameter(), getWheelDiameter()) == 0 &&
+                Double.compare(that.getDriveReduction(), getDriveReduction()) == 0 &&
+                isDriveInverted() == that.isDriveInverted() &&
+                Double.compare(that.getSteerReduction(), getSteerReduction()) == 0 &&
+                isSteerInverted() == that.isSteerInverted() &&
+                getModelIdentifier().equals(that.getModelIdentifier());
     }
 
     @Override
     public int hashCode() {
-        int result = Objects.hash(modelIdentifier, wheelDiameter);
-        result = 31 * result + Arrays.hashCode(driveReductions);
-        result = 31 * result + Arrays.hashCode(steerReductions);
-        return result;
+        return Objects.hash(
+                getModelIdentifier(),
+                getWheelDiameter(),
+                getDriveReduction(),
+                isDriveInverted(),
+                getSteerReduction(),
+                isSteerInverted()
+        );
     }
 
     @Override
@@ -63,8 +78,10 @@ public class ModuleConfiguration {
         return "ModuleConfiguration{" +
                 "modelIdentifier='" + modelIdentifier + '\'' +
                 ", wheelDiameter=" + wheelDiameter +
-                ", driveReductions=" + Arrays.toString(driveReductions) +
-                ", steerReductions=" + Arrays.toString(steerReductions) +
+                ", driveReduction=" + driveReduction +
+                ", driveInverted=" + driveInverted +
+                ", steerReduction=" + steerReduction +
+                ", steerInverted=" + steerInverted +
                 '}';
     }
 }

--- a/src/main/java/com/swervedrivespecialties/swervelib/ModuleConfiguration.java
+++ b/src/main/java/com/swervedrivespecialties/swervelib/ModuleConfiguration.java
@@ -2,6 +2,13 @@ package com.swervedrivespecialties.swervelib;
 
 import java.util.Objects;
 
+/**
+ * A swerve module configuration.
+ * <p>
+ * A configuration represents a unique mechanical configuration of a module. For example, the Swerve Drive Specialties
+ * Mk3 swerve module has two configurations, standard and fast, and therefore should have two configurations
+ * ({@link SdsModuleConfigurations#MK3_STANDARD} and {@link SdsModuleConfigurations#MK3_FAST} respectively).
+ */
 public class ModuleConfiguration {
     private final double wheelDiameter;
     private final double driveReduction;
@@ -10,6 +17,19 @@ public class ModuleConfiguration {
     private final double steerReduction;
     private final boolean steerInverted;
 
+    /**
+     * Creates a new module configuration.
+     *
+     * @param wheelDiameter  The diameter of the module's wheel in meters.
+     * @param driveReduction The overall drive reduction of the module. Multiplying motor rotations by this value
+     *                       should result in wheel rotations.
+     * @param driveInverted  Whether the drive motor should be inverted. If there is an odd number of gea reductions
+     *                       this is typically true.
+     * @param steerReduction The overall steer reduction of the module. Multiplying motor rotations by this value
+     *                       should result in rotations of the steering pulley.
+     * @param steerInverted  Whether the steer motor should be inverted. If there is an odd number of gear reductions
+     *                       this is typically true.
+     */
     public ModuleConfiguration(double wheelDiameter, double driveReduction, boolean driveInverted,
                                double steerReduction, boolean steerInverted) {
         this.wheelDiameter = wheelDiameter;
@@ -19,22 +39,41 @@ public class ModuleConfiguration {
         this.steerInverted = steerInverted;
     }
 
+    /**
+     * Gets the diameter of the wheel in meters.
+     */
     public double getWheelDiameter() {
         return wheelDiameter;
     }
 
+    /**
+     * Gets the overall reduction of the drive system.
+     * <p>
+     * If this value is multiplied by drive motor rotations the result would be drive wheel rotations.
+     */
     public double getDriveReduction() {
         return driveReduction;
     }
 
+    /**
+     * Gets if the drive motor should be inverted.
+     */
     public boolean isDriveInverted() {
         return driveInverted;
     }
 
+    /**
+     * Gets the overall reduction of the steer system.
+     * <p>
+     * If this value is multiplied by steering motor rotations the result would be steering pulley rotations.
+     */
     public double getSteerReduction() {
         return steerReduction;
     }
 
+    /**
+     * Gets if the steering motor should be inverted.
+     */
     public boolean isSteerInverted() {
         return steerInverted;
     }

--- a/src/main/java/com/swervedrivespecialties/swervelib/ModuleConfiguration.java
+++ b/src/main/java/com/swervedrivespecialties/swervelib/ModuleConfiguration.java
@@ -3,8 +3,6 @@ package com.swervedrivespecialties.swervelib;
 import java.util.Objects;
 
 public class ModuleConfiguration {
-    private final String modelIdentifier;
-
     private final double wheelDiameter;
     private final double driveReduction;
     private final boolean driveInverted;
@@ -12,19 +10,13 @@ public class ModuleConfiguration {
     private final double steerReduction;
     private final boolean steerInverted;
 
-    public ModuleConfiguration(String modelIdentifier,
-                               double wheelDiameter, double driveReduction, boolean driveInverted,
+    public ModuleConfiguration(double wheelDiameter, double driveReduction, boolean driveInverted,
                                double steerReduction, boolean steerInverted) {
-        this.modelIdentifier = Objects.requireNonNull(modelIdentifier);
         this.wheelDiameter = wheelDiameter;
         this.driveReduction = driveReduction;
         this.driveInverted = driveInverted;
         this.steerReduction = steerReduction;
         this.steerInverted = steerInverted;
-    }
-
-    public String getModelIdentifier() {
-        return modelIdentifier;
     }
 
     public double getWheelDiameter() {
@@ -52,19 +44,16 @@ public class ModuleConfiguration {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ModuleConfiguration that = (ModuleConfiguration) o;
-        return Double.compare(
-                that.getWheelDiameter(), getWheelDiameter()) == 0 &&
+        return Double.compare(that.getWheelDiameter(), getWheelDiameter()) == 0 &&
                 Double.compare(that.getDriveReduction(), getDriveReduction()) == 0 &&
                 isDriveInverted() == that.isDriveInverted() &&
                 Double.compare(that.getSteerReduction(), getSteerReduction()) == 0 &&
-                isSteerInverted() == that.isSteerInverted() &&
-                getModelIdentifier().equals(that.getModelIdentifier());
+                isSteerInverted() == that.isSteerInverted();
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(
-                getModelIdentifier(),
                 getWheelDiameter(),
                 getDriveReduction(),
                 isDriveInverted(),
@@ -76,8 +65,7 @@ public class ModuleConfiguration {
     @Override
     public String toString() {
         return "ModuleConfiguration{" +
-                "modelIdentifier='" + modelIdentifier + '\'' +
-                ", wheelDiameter=" + wheelDiameter +
+                "wheelDiameter=" + wheelDiameter +
                 ", driveReduction=" + driveReduction +
                 ", driveInverted=" + driveInverted +
                 ", steerReduction=" + steerReduction +

--- a/src/main/java/com/swervedrivespecialties/swervelib/SdsModuleConfigurations.java
+++ b/src/main/java/com/swervedrivespecialties/swervelib/SdsModuleConfigurations.java
@@ -2,7 +2,6 @@ package com.swervedrivespecialties.swervelib;
 
 public final class SdsModuleConfigurations {
     public static final ModuleConfiguration MK3_STANDARD = new ModuleConfiguration(
-            "SDS-Mk3S",
             0.1016,
             (14.0 / 50.0) * (28.0 / 16.0) * (15.0 / 60.0),
             true,
@@ -10,7 +9,6 @@ public final class SdsModuleConfigurations {
             true
     );
     public static final ModuleConfiguration MK3_FAST = new ModuleConfiguration(
-            "SDS-Mk3F",
             0.1016,
             (16.0 / 48.0) * (28.0 / 16.0) * (15.0 / 60.0),
             true,

--- a/src/main/java/com/swervedrivespecialties/swervelib/SdsModuleConfigurations.java
+++ b/src/main/java/com/swervedrivespecialties/swervelib/SdsModuleConfigurations.java
@@ -3,15 +3,19 @@ package com.swervedrivespecialties.swervelib;
 public final class SdsModuleConfigurations {
     public static final ModuleConfiguration MK3_STANDARD = new ModuleConfiguration(
             "SDS-Mk3S",
-            4.0,
-            new double[]{14.0 / 50.0, 28.0 / 16.0, 15.0 / 60.0},
-            new double[]{1.0 / 12.8}
+            0.1016,
+            (14.0 / 50.0) * (28.0 / 16.0) * (15.0 / 60.0),
+            true,
+            (15.0 / 32.0) * (10.0 / 60.0),
+            false
     );
     public static final ModuleConfiguration MK3_FAST = new ModuleConfiguration(
             "SDS-Mk3F",
-            4.0,
-            new double[]{16.0 / 48.0, 28.0 / 16.0, 15.0 / 60.0},
-            new double[]{1.0 / 12.8}
+            0.1016,
+            (16.0 / 48.0) * (28.0 / 16.0) * (15.0 / 60.0),
+            true,
+            (15.0 / 32.0) * (10.0 / 60.0),
+            false
     );
 
     private SdsModuleConfigurations() {

--- a/src/main/java/com/swervedrivespecialties/swervelib/SdsModuleConfigurations.java
+++ b/src/main/java/com/swervedrivespecialties/swervelib/SdsModuleConfigurations.java
@@ -7,7 +7,7 @@ public final class SdsModuleConfigurations {
             (14.0 / 50.0) * (28.0 / 16.0) * (15.0 / 60.0),
             true,
             (15.0 / 32.0) * (10.0 / 60.0),
-            false
+            true
     );
     public static final ModuleConfiguration MK3_FAST = new ModuleConfiguration(
             "SDS-Mk3F",
@@ -15,7 +15,7 @@ public final class SdsModuleConfigurations {
             (16.0 / 48.0) * (28.0 / 16.0) * (15.0 / 60.0),
             true,
             (15.0 / 32.0) * (10.0 / 60.0),
-            false
+            true
     );
 
     private SdsModuleConfigurations() {

--- a/src/main/java/com/swervedrivespecialties/swervelib/ctre/Falcon500SteerControllerFactoryBuilder.java
+++ b/src/main/java/com/swervedrivespecialties/swervelib/ctre/Falcon500SteerControllerFactoryBuilder.java
@@ -3,9 +3,11 @@ package com.swervedrivespecialties.swervelib.ctre;
 import com.ctre.phoenix.motorcontrol.NeutralMode;
 import com.ctre.phoenix.motorcontrol.TalonFXControlMode;
 import com.ctre.phoenix.motorcontrol.TalonFXFeedbackDevice;
+import com.ctre.phoenix.motorcontrol.TalonFXInvertType;
 import com.ctre.phoenix.motorcontrol.can.TalonFX;
 import com.ctre.phoenix.motorcontrol.can.TalonFXConfiguration;
 import com.swervedrivespecialties.swervelib.*;
+import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardContainer;
 
 import static com.swervedrivespecialties.swervelib.ctre.CtreUtils.checkCtreError;
 
@@ -117,6 +119,7 @@ public final class Falcon500SteerControllerFactoryBuilder {
             }
             checkCtreError(motor.configSelectedFeedbackSensor(TalonFXFeedbackDevice.IntegratedSensor, 0, 250), "Failed to set Falcon 500 feedback sensor");
             motor.setSensorPhase(moduleConfiguration.isSteerInverted());
+            motor.setInverted(TalonFXInvertType.CounterClockwise);
             motor.setNeutralMode(NeutralMode.Brake);
 
             checkCtreError(motor.setSelectedSensorPosition(absoluteEncoder.getAbsoluteAngle() / sensorPositionCoefficient, 0, 250), "Failed to set Falcon 500 encoder position");

--- a/src/main/java/com/swervedrivespecialties/swervelib/ctre/Falcon500SteerControllerFactoryBuilder.java
+++ b/src/main/java/com/swervedrivespecialties/swervelib/ctre/Falcon500SteerControllerFactoryBuilder.java
@@ -80,7 +80,7 @@ public final class Falcon500SteerControllerFactoryBuilder {
         public ControllerImplementation create(Falcon500SteerConfiguration<T> steerConfiguration, ModuleConfiguration moduleConfiguration) {
             AbsoluteEncoder absoluteEncoder = encoderFactory.create(steerConfiguration.getEncoderConfiguration());
 
-            final double sensorPositionCoefficient = 2.0 * Math.PI / TICKS_PER_ROTATION * moduleConfiguration.getOverallSteerReduction();
+            final double sensorPositionCoefficient = 2.0 * Math.PI / TICKS_PER_ROTATION * moduleConfiguration.getSteerReduction();
             final double sensorVelocityCoefficient = sensorPositionCoefficient * 10.0;
 
             TalonFXConfiguration motorConfiguration = new TalonFXConfiguration();
@@ -116,7 +116,7 @@ public final class Falcon500SteerControllerFactoryBuilder {
                 motor.enableVoltageCompensation(true);
             }
             checkCtreError(motor.configSelectedFeedbackSensor(TalonFXFeedbackDevice.IntegratedSensor, 0, 250), "Failed to set Falcon 500 feedback sensor");
-            motor.setSensorPhase(moduleConfiguration.getSteerReductions().length % 2 == 0);
+            motor.setSensorPhase(moduleConfiguration.isSteerInverted());
             motor.setNeutralMode(NeutralMode.Brake);
 
             checkCtreError(motor.setSelectedSensorPosition(absoluteEncoder.getAbsoluteAngle() / sensorPositionCoefficient, 0, 250), "Failed to set Falcon 500 encoder position");

--- a/src/main/java/com/swervedrivespecialties/swervelib/rev/NeoDriveControllerFactoryBuilder.java
+++ b/src/main/java/com/swervedrivespecialties/swervelib/rev/NeoDriveControllerFactoryBuilder.java
@@ -28,7 +28,7 @@ public final class NeoDriveControllerFactoryBuilder {
         @Override
         public ControllerImplementation create(Integer id, ModuleConfiguration moduleConfiguration) {
             CANSparkMax motor = new CANSparkMax(id, CANSparkMaxLowLevel.MotorType.kBrushless);
-            motor.setInverted(moduleConfiguration.getDriveReductions().length % 2 == 0);
+            motor.setInverted(moduleConfiguration.isDriveInverted());
 
             // TODO: Configure builtin encoder
             // TODO: Configure CAN frame rates

--- a/src/main/java/com/swervedrivespecialties/swervelib/rev/NeoSteerControllerFactoryBuilder.java
+++ b/src/main/java/com/swervedrivespecialties/swervelib/rev/NeoSteerControllerFactoryBuilder.java
@@ -65,7 +65,7 @@ public class NeoSteerControllerFactoryBuilder {
 
             CANSparkMax motor = new CANSparkMax(steerConfiguration.getMotorPort(), CANSparkMaxLowLevel.MotorType.kBrushless);
             RevUtils.checkNeoError(motor.setIdleMode(CANSparkMax.IdleMode.kBrake), "Failed to set NEO idle mode");
-            motor.setInverted(moduleConfiguration.isSteerInverted());
+            motor.setInverted(!moduleConfiguration.isSteerInverted());
             if (hasVoltageCompensation()) {
                 RevUtils.checkNeoError(motor.enableVoltageCompensation(nominalVoltage), "Failed to enable voltage compensation");
             }

--- a/src/main/java/com/swervedrivespecialties/swervelib/rev/NeoSteerControllerFactoryBuilder.java
+++ b/src/main/java/com/swervedrivespecialties/swervelib/rev/NeoSteerControllerFactoryBuilder.java
@@ -65,7 +65,7 @@ public class NeoSteerControllerFactoryBuilder {
 
             CANSparkMax motor = new CANSparkMax(steerConfiguration.getMotorPort(), CANSparkMaxLowLevel.MotorType.kBrushless);
             RevUtils.checkNeoError(motor.setIdleMode(CANSparkMax.IdleMode.kBrake), "Failed to set NEO idle mode");
-            motor.setInverted(moduleConfiguration.getSteerReductions().length % 2 == 0);
+            motor.setInverted(moduleConfiguration.isSteerInverted());
             if (hasVoltageCompensation()) {
                 RevUtils.checkNeoError(motor.enableVoltageCompensation(nominalVoltage), "Failed to enable voltage compensation");
             }
@@ -74,7 +74,7 @@ public class NeoSteerControllerFactoryBuilder {
             }
 
             CANEncoder integratedEncoder = motor.getEncoder();
-            RevUtils.checkNeoError(integratedEncoder.setPositionConversionFactor(2.0 * Math.PI * moduleConfiguration.getOverallSteerReduction()), "Failed to set NEO encoder conversion factor");
+            RevUtils.checkNeoError(integratedEncoder.setPositionConversionFactor(2.0 * Math.PI * moduleConfiguration.getSteerReduction()), "Failed to set NEO encoder conversion factor");
             RevUtils.checkNeoError(integratedEncoder.setPosition(absoluteEncoder.getAbsoluteAngle()), "Failed to set NEO encoder position");
 
             CANPIDController controller = motor.getPIDController();

--- a/src/test/java/com/swervedrivespecialties/swervelib/SdsModuleConfigurationsTest.java
+++ b/src/test/java/com/swervedrivespecialties/swervelib/SdsModuleConfigurationsTest.java
@@ -6,13 +6,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SdsModuleConfigurationsTest {
     @Test
-    void mk3StandardOverallReduction() {
+    void mk3StandardReductions() {
         assertEquals(1.0 / 8.16, SdsModuleConfigurations.MK3_STANDARD.getDriveReduction(), 1e-4);
         assertEquals(1.0 / 12.8, SdsModuleConfigurations.MK3_STANDARD.getSteerReduction(), 1e-4);
     }
 
     @Test
-    void mk3FastOverallDriveReduction() {
+    void mk3FastReductions() {
         assertEquals(1.0 / 6.86, SdsModuleConfigurations.MK3_FAST.getDriveReduction(), 1e-4);
         assertEquals(1.0 / 12.8, SdsModuleConfigurations.MK3_FAST.getSteerReduction(), 1e-4);
     }

--- a/src/test/java/com/swervedrivespecialties/swervelib/SdsModuleConfigurationsTest.java
+++ b/src/test/java/com/swervedrivespecialties/swervelib/SdsModuleConfigurationsTest.java
@@ -6,12 +6,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SdsModuleConfigurationsTest {
     @Test
-    void mk3StandardOverallDriveReduction() {
-        assertEquals(1.0 / 8.16, SdsModuleConfigurations.MK3_STANDARD.getOverallDriveReduction(), 1e-4);
+    void mk3StandardOverallReduction() {
+        assertEquals(1.0 / 8.16, SdsModuleConfigurations.MK3_STANDARD.getDriveReduction(), 1e-4);
+        assertEquals(1.0 / 12.8, SdsModuleConfigurations.MK3_STANDARD.getSteerReduction(), 1e-4);
     }
 
     @Test
     void mk3FastOverallDriveReduction() {
-        assertEquals(1.0 / 6.86, SdsModuleConfigurations.MK3_FAST.getOverallDriveReduction(), 1e-4);
+        assertEquals(1.0 / 6.86, SdsModuleConfigurations.MK3_FAST.getDriveReduction(), 1e-4);
+        assertEquals(1.0 / 12.8, SdsModuleConfigurations.MK3_FAST.getSteerReduction(), 1e-4);
     }
 }


### PR DESCRIPTION
Gear ratios used to be specified one stage at a time. This was intended to allow for the ability to dynamically determine whether or not to invert motors. However, not every type of reduction stage inverts the direction of motion. For example, a gear reduction changes the direction of motion while a belt and pulley reduction does not.