### PR TITLE
Report CTRE and REVLib errors on Dashboard instead of throwing exception

### DIFF
--- a/src/main/java/com/swervedrivespecialties/swervelib/ctre/CtreUtils.java
+++ b/src/main/java/com/swervedrivespecialties/swervelib/ctre/CtreUtils.java
@@ -2,13 +2,14 @@ package com.swervedrivespecialties.swervelib.ctre;
 
 import com.ctre.phoenix.ErrorCode;
 
+import edu.wpi.first.wpilibj.DriverStation;
+
 public final class CtreUtils {
-    private CtreUtils() {
-    }
+    private CtreUtils() {}
 
     public static void checkCtreError(ErrorCode errorCode, String message) {
         if (errorCode != ErrorCode.OK) {
-            throw new RuntimeException(String.format("%s: %s", message, errorCode.toString()));
+            DriverStation.reportError(String.format("%s: %s", message, errorCode.toString()), false);
         }
     }
 }

--- a/src/main/java/com/swervedrivespecialties/swervelib/rev/RevUtils.java
+++ b/src/main/java/com/swervedrivespecialties/swervelib/rev/RevUtils.java
@@ -2,12 +2,14 @@ package com.swervedrivespecialties.swervelib.rev;
 
 import com.revrobotics.REVLibError;
 
+import edu.wpi.first.wpilibj.DriverStation;
+
 public final class RevUtils {
     private RevUtils() {}
 
     public static void checkNeoError(REVLibError error, String message) {
         if (error != REVLibError.kOk) {
-            throw new RuntimeException(String.format("%s: %s", message, error.toString()));
+            DriverStation.reportError(String.format("%s: %s", message, error.toString()), false);
         }
     }
 }


### PR DESCRIPTION
Taking guidance from [254's code](https://github.com/Team254/FRC-2020-Public/blob/eb828c6159d738b09a574993feb4c407f0cda4a7/src/main/java/com/team254/lib/drivers/TalonUtil.java#L15) and [Jacob's issue](https://github.com/SwerveDriveSpecialties/swerve-lib/issues/7) - this PR changes the CTRE and REVLib errors to be reported on the Dashboard instead of throwing an exception.