### PR TITLE
CAN FD CANivore support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 /.gradle/
 /build/
 /examples/*/build/
+/examples/*/bin/
+/bin/
 
 # Intellij Project Files
 /.idea/

--- a/src/main/java/com/swervedrivespecialties/swervelib/Mk3ModuleConfiguration.java
+++ b/src/main/java/com/swervedrivespecialties/swervelib/Mk3ModuleConfiguration.java
@@ -13,6 +13,21 @@ public class Mk3ModuleConfiguration {
     private double driveCurrentLimit = 80.0;
     private double steerCurrentLimit = 20.0;
 
+    private String canivoreName = "";
+
+    public void setCanivoreName(String canivoreName) {
+        this.canivoreName = canivoreName;
+    }
+
+    public String getCanivoreName() {
+        return canivoreName;
+    }
+
+    public boolean useCanivore() {
+        // null or empty canivore name means don't use canivore
+        return !(canivoreName == null || canivoreName.isEmpty());
+    }
+
     public double getNominalVoltage() {
         return nominalVoltage;
     }
@@ -56,6 +71,7 @@ public class Mk3ModuleConfiguration {
                 "nominalVoltage=" + nominalVoltage +
                 ", driveCurrentLimit=" + driveCurrentLimit +
                 ", steerCurrentLimit=" + steerCurrentLimit +
+                ", canivoreName='" + canivoreName +
                 '}';
     }
 }

--- a/src/main/java/com/swervedrivespecialties/swervelib/Mk3SwerveModuleHelper.java
+++ b/src/main/java/com/swervedrivespecialties/swervelib/Mk3SwerveModuleHelper.java
@@ -14,6 +14,7 @@ public final class Mk3SwerveModuleHelper {
         return new Falcon500DriveControllerFactoryBuilder()
                 .withVoltageCompensation(configuration.getNominalVoltage())
                 .withCurrentLimit(configuration.getDriveCurrentLimit())
+                .withCanivoreName(configuration.getCanivoreName())
                 .build();
     }
 
@@ -22,8 +23,10 @@ public final class Mk3SwerveModuleHelper {
                 .withVoltageCompensation(configuration.getNominalVoltage())
                 .withPidConstants(0.2, 0.0, 0.1)
                 .withCurrentLimit(configuration.getSteerCurrentLimit())
+                .withCanivoreName(configuration.getCanivoreName())
                 .build(new CanCoderFactoryBuilder()
                         .withReadingUpdatePeriod(100)
+                        .withCanivoreName(configuration.getCanivoreName())
                         .build());
     }
 
@@ -41,6 +44,7 @@ public final class Mk3SwerveModuleHelper {
                 .withCurrentLimit(configuration.getSteerCurrentLimit())
                 .build(new CanCoderFactoryBuilder()
                         .withReadingUpdatePeriod(100)
+                        .withCanivoreName(configuration.getCanivoreName())
                         .build());
     }
 

--- a/src/main/java/com/swervedrivespecialties/swervelib/Mk4ModuleConfiguration.java
+++ b/src/main/java/com/swervedrivespecialties/swervelib/Mk4ModuleConfiguration.java
@@ -12,6 +12,20 @@ public class Mk4ModuleConfiguration {
     private double nominalVoltage = 12.0;
     private double driveCurrentLimit = 80.0;
     private double steerCurrentLimit = 20.0;
+    private String canivoreName = "";
+
+    public void setCanivoreName(String canivoreName) {
+        this.canivoreName = canivoreName;
+    }
+
+    public String getCanivoreName() {
+        return canivoreName;
+    }
+
+    public boolean useCanivore() {
+        // null or empty canivore name means don't use canivore
+        return !(canivoreName == null || canivoreName.isEmpty());
+    }
 
     public double getNominalVoltage() {
         return nominalVoltage;
@@ -56,6 +70,7 @@ public class Mk4ModuleConfiguration {
                 "nominalVoltage=" + nominalVoltage +
                 ", driveCurrentLimit=" + driveCurrentLimit +
                 ", steerCurrentLimit=" + steerCurrentLimit +
+                ", canivoreName='" + canivoreName +
                 '}';
     }
 }

--- a/src/main/java/com/swervedrivespecialties/swervelib/Mk4SwerveModuleHelper.java
+++ b/src/main/java/com/swervedrivespecialties/swervelib/Mk4SwerveModuleHelper.java
@@ -14,6 +14,7 @@ public final class Mk4SwerveModuleHelper {
         return new Falcon500DriveControllerFactoryBuilder()
                 .withVoltageCompensation(configuration.getNominalVoltage())
                 .withCurrentLimit(configuration.getDriveCurrentLimit())
+                .withCanivoreName(configuration.getCanivoreName())
                 .build();
     }
 
@@ -22,8 +23,10 @@ public final class Mk4SwerveModuleHelper {
                 .withVoltageCompensation(configuration.getNominalVoltage())
                 .withPidConstants(0.2, 0.0, 0.1)
                 .withCurrentLimit(configuration.getSteerCurrentLimit())
+                .withCanivoreName(configuration.getCanivoreName())
                 .build(new CanCoderFactoryBuilder()
                         .withReadingUpdatePeriod(100)
+                        .withCanivoreName(configuration.getCanivoreName())
                         .build());
     }
 
@@ -41,6 +44,7 @@ public final class Mk4SwerveModuleHelper {
                 .withCurrentLimit(configuration.getSteerCurrentLimit())
                 .build(new CanCoderFactoryBuilder()
                         .withReadingUpdatePeriod(100)
+                        .withCanivoreName(configuration.getCanivoreName())
                         .build());
     }
 
@@ -130,7 +134,8 @@ public final class Mk4SwerveModuleHelper {
                 driveMotorPort,
                 new Falcon500SteerConfiguration<>(
                         steerMotorPort,
-                        new CanCoderAbsoluteConfiguration(steerEncoderPort, steerOffset)
+                        new CanCoderAbsoluteConfiguration(steerEncoderPort, steerOffset),
+                        configuration.getCanivoreName()
                 )
         );
     }
@@ -408,7 +413,8 @@ public final class Mk4SwerveModuleHelper {
                 driveMotorPort,
                 new Falcon500SteerConfiguration<>(
                         steerMotorPort,
-                        new CanCoderAbsoluteConfiguration(steerEncoderPort, steerOffset)
+                        new CanCoderAbsoluteConfiguration(steerEncoderPort, steerOffset),
+                        configuration.getCanivoreName()
                 )
         );
     }
@@ -463,7 +469,8 @@ public final class Mk4SwerveModuleHelper {
                 driveMotorPort,
                 new Falcon500SteerConfiguration<>(
                         steerMotorPort,
-                        new CanCoderAbsoluteConfiguration(steerEncoderPort, steerOffset)
+                        new CanCoderAbsoluteConfiguration(steerEncoderPort, steerOffset),
+                        configuration.getCanivoreName()
                 )
         );
     }

--- a/src/main/java/com/swervedrivespecialties/swervelib/Mk4iSwerveModuleHelper.java
+++ b/src/main/java/com/swervedrivespecialties/swervelib/Mk4iSwerveModuleHelper.java
@@ -14,6 +14,7 @@ public final class Mk4iSwerveModuleHelper {
         return new Falcon500DriveControllerFactoryBuilder()
                 .withVoltageCompensation(configuration.getNominalVoltage())
                 .withCurrentLimit(configuration.getDriveCurrentLimit())
+                .withCanivoreName(configuration.getCanivoreName())
                 .build();
     }
 
@@ -22,8 +23,10 @@ public final class Mk4iSwerveModuleHelper {
                 .withVoltageCompensation(configuration.getNominalVoltage())
                 .withPidConstants(0.2, 0.0, 0.1)
                 .withCurrentLimit(configuration.getSteerCurrentLimit())
+                .withCanivoreName(configuration.getCanivoreName())
                 .build(new CanCoderFactoryBuilder()
                         .withReadingUpdatePeriod(100)
+                        .withCanivoreName(configuration.getCanivoreName())
                         .build());
     }
 
@@ -41,6 +44,7 @@ public final class Mk4iSwerveModuleHelper {
                 .withCurrentLimit(configuration.getSteerCurrentLimit())
                 .build(new CanCoderFactoryBuilder()
                         .withReadingUpdatePeriod(100)
+                        .withCanivoreName(configuration.getCanivoreName())
                         .build());
     }
 
@@ -75,7 +79,8 @@ public final class Mk4iSwerveModuleHelper {
                 driveMotorPort,
                 new Falcon500SteerConfiguration<>(
                         steerMotorPort,
-                        new CanCoderAbsoluteConfiguration(steerEncoderPort, steerOffset)
+                        new CanCoderAbsoluteConfiguration(steerEncoderPort, steerOffset),
+                        configuration.getCanivoreName()
                 )
         );
     }
@@ -130,7 +135,8 @@ public final class Mk4iSwerveModuleHelper {
                 driveMotorPort,
                 new Falcon500SteerConfiguration<>(
                         steerMotorPort,
-                        new CanCoderAbsoluteConfiguration(steerEncoderPort, steerOffset)
+                        new CanCoderAbsoluteConfiguration(steerEncoderPort, steerOffset),
+                        configuration.getCanivoreName()
                 )
         );
     }
@@ -408,7 +414,8 @@ public final class Mk4iSwerveModuleHelper {
                 driveMotorPort,
                 new Falcon500SteerConfiguration<>(
                         steerMotorPort,
-                        new CanCoderAbsoluteConfiguration(steerEncoderPort, steerOffset)
+                        new CanCoderAbsoluteConfiguration(steerEncoderPort, steerOffset),
+                        configuration.getCanivoreName()
                 )
         );
     }
@@ -463,7 +470,8 @@ public final class Mk4iSwerveModuleHelper {
                 driveMotorPort,
                 new Falcon500SteerConfiguration<>(
                         steerMotorPort,
-                        new CanCoderAbsoluteConfiguration(steerEncoderPort, steerOffset)
+                        new CanCoderAbsoluteConfiguration(steerEncoderPort, steerOffset),
+                        configuration.getCanivoreName()
                 )
         );
     }

--- a/src/main/java/com/swervedrivespecialties/swervelib/ModuleConfiguration.java
+++ b/src/main/java/com/swervedrivespecialties/swervelib/ModuleConfiguration.java
@@ -16,6 +16,8 @@ public class ModuleConfiguration {
 
     private final double steerReduction;
     private final boolean steerInverted;
+    
+    private final String canivoreName;
 
     /**
      * Creates a new module configuration.
@@ -37,6 +39,43 @@ public class ModuleConfiguration {
         this.driveInverted = driveInverted;
         this.steerReduction = steerReduction;
         this.steerInverted = steerInverted;
+        this.canivoreName = "";
+    }
+
+    /**
+     * Creates a new module configuration.
+     *
+     * @param wheelDiameter  The diameter of the module's wheel in meters.
+     * @param driveReduction The overall drive reduction of the module. Multiplying motor rotations by this value
+     *                       should result in wheel rotations.
+     * @param driveInverted  Whether the drive motor should be inverted. If there is an odd number of gea reductions
+     *                       this is typically true.
+     * @param steerReduction The overall steer reduction of the module. Multiplying motor rotations by this value
+     *                       should result in rotations of the steering pulley.
+     * @param steerInverted  Whether the steer motor should be inverted. If there is an odd number of gear reductions
+     *                       this is typically true.
+     * @param canivoreName   The name of the CANivore to use for this module.
+     */
+    public ModuleConfiguration(double wheelDiameter, double driveReduction, boolean driveInverted,
+            double steerReduction, boolean steerInverted, String canivoreName) {
+        this.wheelDiameter = wheelDiameter;
+        this.driveReduction = driveReduction;
+        this.driveInverted = driveInverted;
+        this.steerReduction = steerReduction;
+        this.steerInverted = steerInverted;
+        this.canivoreName = canivoreName;
+    }
+
+    /**
+     * Gets name of CANivore to use for this module.
+     */
+    public String getCanivoreName() {
+        return canivoreName;
+    }
+
+    public boolean useCanivore() {
+        // null or empty canivore name means don't use canivore
+        return !(canivoreName == null || canivoreName.isEmpty());
     }
 
     /**
@@ -109,6 +148,7 @@ public class ModuleConfiguration {
                 ", driveInverted=" + driveInverted +
                 ", steerReduction=" + steerReduction +
                 ", steerInverted=" + steerInverted +
+                ", canivoreName='" + canivoreName +
                 '}';
     }
 }

--- a/src/main/java/com/swervedrivespecialties/swervelib/ctre/CanCoderFactoryBuilder.java
+++ b/src/main/java/com/swervedrivespecialties/swervelib/ctre/CanCoderFactoryBuilder.java
@@ -40,12 +40,8 @@ public class CanCoderFactoryBuilder {
             config.magnetOffsetDegrees = Math.toDegrees(configuration.getOffset());
             config.sensorDirection = direction == Direction.CLOCKWISE;
 
-            CANCoder encoder;
-            if (useCanivore()) {
-                encoder = new CANCoder(configuration.getId(), canivoreName);
-            } else {
-                encoder = new CANCoder(configuration.getId());
-            }
+            CANCoder encoder = new CANCoder(configuration.getId(), canivoreName);
+
             CtreUtils.checkCtreError(encoder.configAllSettings(config, 250), "Failed to configure CANCoder");
 
             CtreUtils.checkCtreError(encoder.setStatusFramePeriod(CANCoderStatusFrame.SensorData, periodMilliseconds, 250), "Failed to configure CANCoder update rate");

--- a/src/main/java/com/swervedrivespecialties/swervelib/ctre/CanCoderFactoryBuilder.java
+++ b/src/main/java/com/swervedrivespecialties/swervelib/ctre/CanCoderFactoryBuilder.java
@@ -10,6 +10,8 @@ import com.swervedrivespecialties.swervelib.AbsoluteEncoderFactory;
 public class CanCoderFactoryBuilder {
     private Direction direction = Direction.COUNTER_CLOCKWISE;
     private int periodMilliseconds = 10;
+    private String canivoreName = "";
+
 
     public CanCoderFactoryBuilder withReadingUpdatePeriod(int periodMilliseconds) {
         this.periodMilliseconds = periodMilliseconds;
@@ -21,6 +23,16 @@ public class CanCoderFactoryBuilder {
         return this;
     }
 
+    public CanCoderFactoryBuilder withCanivoreName(String canivoreName) {
+        this.canivoreName = canivoreName;
+        return this;
+    }
+
+    public boolean useCanivore() {
+        // null or empty canivore name means don't use canivore
+        return !(canivoreName == null || canivoreName.isEmpty());
+    }
+
     public AbsoluteEncoderFactory<CanCoderAbsoluteConfiguration> build() {
         return configuration -> {
             CANCoderConfiguration config = new CANCoderConfiguration();
@@ -28,7 +40,12 @@ public class CanCoderFactoryBuilder {
             config.magnetOffsetDegrees = Math.toDegrees(configuration.getOffset());
             config.sensorDirection = direction == Direction.CLOCKWISE;
 
-            CANCoder encoder = new CANCoder(configuration.getId());
+            CANCoder encoder;
+            if (useCanivore()) {
+                encoder = new CANCoder(configuration.getId(), canivoreName);
+            } else {
+                encoder = new CANCoder(configuration.getId());
+            }
             CtreUtils.checkCtreError(encoder.configAllSettings(config, 250), "Failed to configure CANCoder");
 
             CtreUtils.checkCtreError(encoder.setStatusFramePeriod(CANCoderStatusFrame.SensorData, periodMilliseconds, 250), "Failed to configure CANCoder update rate");

--- a/src/main/java/com/swervedrivespecialties/swervelib/ctre/Falcon500DriveControllerFactoryBuilder.java
+++ b/src/main/java/com/swervedrivespecialties/swervelib/ctre/Falcon500DriveControllerFactoryBuilder.java
@@ -70,13 +70,8 @@ public final class Falcon500DriveControllerFactoryBuilder {
                 motorConfiguration.supplyCurrLimit.enable = true;
             }
 
-            TalonFX motor;
-            if (useCanivore()) {
-                motor = new TalonFX(driveConfiguration, moduleConfiguration.getCanivoreName());
-                SmartDashboard.putString("DRIVE_CANivore" + driveConfiguration, canivoreName);
-            } else {
-                motor = new TalonFX(driveConfiguration);
-            }
+            TalonFX motor = new TalonFX(driveConfiguration, moduleConfiguration.getCanivoreName());
+
             CtreUtils.checkCtreError(motor.configAllSettings(motorConfiguration), "Failed to configure Falcon 500");
 
             if (hasVoltageCompensation()) {

--- a/src/main/java/com/swervedrivespecialties/swervelib/ctre/Falcon500DriveControllerFactoryBuilder.java
+++ b/src/main/java/com/swervedrivespecialties/swervelib/ctre/Falcon500DriveControllerFactoryBuilder.java
@@ -9,6 +9,7 @@ import com.ctre.phoenix.motorcontrol.can.TalonFXConfiguration;
 import com.swervedrivespecialties.swervelib.DriveController;
 import com.swervedrivespecialties.swervelib.DriveControllerFactory;
 import com.swervedrivespecialties.swervelib.ModuleConfiguration;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 
 public final class Falcon500DriveControllerFactoryBuilder {
     private static final double TICKS_PER_ROTATION = 2048.0;
@@ -18,10 +19,21 @@ public final class Falcon500DriveControllerFactoryBuilder {
 
     private double nominalVoltage = Double.NaN;
     private double currentLimit = Double.NaN;
+    private String canivoreName = "";
 
     public Falcon500DriveControllerFactoryBuilder withVoltageCompensation(double nominalVoltage) {
         this.nominalVoltage = nominalVoltage;
         return this;
+    }
+
+    public Falcon500DriveControllerFactoryBuilder withCanivoreName(String canivoreName){
+        this.canivoreName = canivoreName;
+        return this;
+    }
+
+    public boolean useCanivore() {
+        // null or empty canivore name means don't use canivore
+        return !(canivoreName == null || canivoreName.isEmpty());
     }
 
     public boolean hasVoltageCompensation() {
@@ -58,7 +70,13 @@ public final class Falcon500DriveControllerFactoryBuilder {
                 motorConfiguration.supplyCurrLimit.enable = true;
             }
 
-            TalonFX motor = new TalonFX(driveConfiguration);
+            TalonFX motor;
+            if (useCanivore()) {
+                motor = new TalonFX(driveConfiguration, moduleConfiguration.getCanivoreName());
+                SmartDashboard.putString("DRIVE_CANivore" + driveConfiguration, canivoreName);
+            } else {
+                motor = new TalonFX(driveConfiguration);
+            }
             CtreUtils.checkCtreError(motor.configAllSettings(motorConfiguration), "Failed to configure Falcon 500");
 
             if (hasVoltageCompensation()) {

--- a/src/main/java/com/swervedrivespecialties/swervelib/ctre/Falcon500SteerConfiguration.java
+++ b/src/main/java/com/swervedrivespecialties/swervelib/ctre/Falcon500SteerConfiguration.java
@@ -5,10 +5,30 @@ import java.util.Objects;
 public class Falcon500SteerConfiguration<EncoderConfiguration> {
     private final int motorPort;
     private final EncoderConfiguration encoderConfiguration;
+    private String canivoreName = "";
 
     public Falcon500SteerConfiguration(int motorPort, EncoderConfiguration encoderConfiguration) {
         this.motorPort = motorPort;
         this.encoderConfiguration = encoderConfiguration;
+        this.canivoreName = "";
+    }
+
+    public Falcon500SteerConfiguration(int motorPort, EncoderConfiguration encoderConfiguration, String canivoreName) {
+        this.motorPort = motorPort;
+        this.encoderConfiguration = encoderConfiguration;
+        this.canivoreName = canivoreName;
+    }
+
+    /**
+     * Gets name of CANivore to use for this module.
+     */
+    public String getCanivoreName() {
+        return canivoreName;
+    }
+
+    public boolean useCanivore() {
+        // null or empty canivore name means don't use canivore
+        return !(canivoreName == null || canivoreName.isEmpty());
     }
 
     public int getMotorPort() {

--- a/src/main/java/com/swervedrivespecialties/swervelib/ctre/Falcon500SteerControllerFactoryBuilder.java
+++ b/src/main/java/com/swervedrivespecialties/swervelib/ctre/Falcon500SteerControllerFactoryBuilder.java
@@ -5,7 +5,7 @@ import com.ctre.phoenix.motorcontrol.can.TalonFX;
 import com.ctre.phoenix.motorcontrol.can.TalonFXConfiguration;
 import com.swervedrivespecialties.swervelib.*;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardContainer;
-
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import static com.swervedrivespecialties.swervelib.ctre.CtreUtils.checkCtreError;
 
 public final class Falcon500SteerControllerFactoryBuilder {
@@ -27,11 +27,23 @@ public final class Falcon500SteerControllerFactoryBuilder {
     private double nominalVoltage = Double.NaN;
     private double currentLimit = Double.NaN;
 
+    private String canivoreName = "";
+
     public Falcon500SteerControllerFactoryBuilder withPidConstants(double proportional, double integral, double derivative) {
         this.proportionalConstant = proportional;
         this.integralConstant = integral;
         this.derivativeConstant = derivative;
         return this;
+    }
+
+    public Falcon500SteerControllerFactoryBuilder withCanivoreName(String canivoreName){
+        this.canivoreName = canivoreName;
+        return this;
+    }
+
+    public boolean useCanivore() {
+        // null or empty canivore name means don't use canivore
+        return !(canivoreName == null || canivoreName.isEmpty());
     }
 
     public boolean hasPidConstants() {
@@ -115,7 +127,13 @@ public final class Falcon500SteerControllerFactoryBuilder {
                 motorConfiguration.supplyCurrLimit.enable = true;
             }
 
-            TalonFX motor = new TalonFX(steerConfiguration.getMotorPort());
+            TalonFX motor;
+            if (steerConfiguration.useCanivore()) {
+                motor = new TalonFX(steerConfiguration.getMotorPort(), steerConfiguration.getCanivoreName());
+                SmartDashboard.putString("STEER_CANivore" + steerConfiguration.getMotorPort(), steerConfiguration.getCanivoreName());
+            } else {
+                motor = new TalonFX(steerConfiguration.getMotorPort());
+            }
             checkCtreError(motor.configAllSettings(motorConfiguration, CAN_TIMEOUT_MS), "Failed to configure Falcon 500 settings");
 
             if (hasVoltageCompensation()) {

--- a/src/main/java/com/swervedrivespecialties/swervelib/ctre/Falcon500SteerControllerFactoryBuilder.java
+++ b/src/main/java/com/swervedrivespecialties/swervelib/ctre/Falcon500SteerControllerFactoryBuilder.java
@@ -127,13 +127,7 @@ public final class Falcon500SteerControllerFactoryBuilder {
                 motorConfiguration.supplyCurrLimit.enable = true;
             }
 
-            TalonFX motor;
-            if (steerConfiguration.useCanivore()) {
-                motor = new TalonFX(steerConfiguration.getMotorPort(), steerConfiguration.getCanivoreName());
-                SmartDashboard.putString("STEER_CANivore" + steerConfiguration.getMotorPort(), steerConfiguration.getCanivoreName());
-            } else {
-                motor = new TalonFX(steerConfiguration.getMotorPort());
-            }
+            TalonFX motor = new TalonFX(steerConfiguration.getMotorPort(), steerConfiguration.getCanivoreName());
             checkCtreError(motor.configAllSettings(motorConfiguration, CAN_TIMEOUT_MS), "Failed to configure Falcon 500 settings");
 
             if (hasVoltageCompensation()) {


### PR DESCRIPTION
I added support for connecting FalonFX and CANivore devices using CAN FD over a CANivore.

CANivore use defaults to being off, and is enabled by calling `setCanivoreName(String)` 

I couldn't find another implementation that didn't also include other features and/or was part of someome's dev branch.